### PR TITLE
Fix linker issue with static library

### DIFF
--- a/JJException.xcodeproj/project.pbxproj
+++ b/JJException.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		61A7F5602144ED9D00C87FA1 /* NSNotificationCenter+ClearNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A7F55D2144ED9C00C87FA1 /* NSNotificationCenter+ClearNotification.m */; };
 		61A7F5632145071800C87FA1 /* KVOObjectDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A7F5622145071800C87FA1 /* KVOObjectDemo.m */; };
 		61BC3FC720F7ACE500D8C791 /* JJExceptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61BC3FC620F7ACE500D8C791 /* JJExceptionTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		93DC6F6922254D7000BA3EFD /* JJExceptionMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 93DC6F6822254D7000BA3EFD /* JJExceptionMacros.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -147,6 +148,7 @@
 		61BC3FC420F7ACE500D8C791 /* JJExceptionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JJExceptionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		61BC3FC620F7ACE500D8C791 /* JJExceptionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JJExceptionTests.m; sourceTree = "<group>"; };
 		61BC3FC820F7ACE500D8C791 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		93DC6F6822254D7000BA3EFD /* JJExceptionMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JJExceptionMacros.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -244,6 +246,7 @@
 				613E0A94214974B800B8D0DF /* JJExceptionProxy.m */,
 				613E0A8C21496ED100B8D0DF /* JJException.h */,
 				613E0A8B21496ED100B8D0DF /* JJException.m */,
+				93DC6F6822254D7000BA3EFD /* JJExceptionMacros.h */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -327,6 +330,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61025B8B21563ABB00191522 /* JJException.h in Headers */,
+				93DC6F6922254D7000BA3EFD /* JJExceptionMacros.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JJException/Source/ARC/NSAttributedString+AttributedStringHook.m
+++ b/JJException/Source/ARC/NSAttributedString+AttributedStringHook.m
@@ -10,6 +10,9 @@
 #import "NSObject+SwizzleHook.h"
 #import <objc/runtime.h>
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSAttributedString_AttributedStringHook)
 
 @implementation NSAttributedString (AttributedStringHook)
 

--- a/JJException/Source/ARC/NSMutableAttributedString+MutableAttributedStringHook.m
+++ b/JJException/Source/ARC/NSMutableAttributedString+MutableAttributedStringHook.m
@@ -10,6 +10,9 @@
 #import "NSObject+SwizzleHook.h"
 #import <objc/runtime.h>
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSMutableAttributedString_MutableAttributedStringHook)
 
 @implementation NSMutableAttributedString (MutableAttributedStringHook)
 

--- a/JJException/Source/ARC/NSMutableSet+MutableSetHook.m
+++ b/JJException/Source/ARC/NSMutableSet+MutableSetHook.m
@@ -10,6 +10,9 @@
 #import "NSObject+SwizzleHook.h"
 #import <objc/runtime.h>
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSMutableSet_MutableSetHook)
 
 @implementation NSMutableSet (MutableSetHook)
 

--- a/JJException/Source/ARC/NSMutableString+MutableStringHook.m
+++ b/JJException/Source/ARC/NSMutableString+MutableStringHook.m
@@ -9,6 +9,9 @@
 #import "NSMutableString+MutableStringHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSMutableString_MutableStringHook)
 
 @implementation NSMutableString (MutableStringHook)
 

--- a/JJException/Source/ARC/NSNotificationCenter+ClearNotification.m
+++ b/JJException/Source/ARC/NSNotificationCenter+ClearNotification.m
@@ -9,7 +9,10 @@
 #import "NSNotificationCenter+ClearNotification.h"
 #import "NSObject+SwizzleHook.h"
 #import "NSObject+DeallocBlock.h"
+#import "JJExceptionMacros.h"
 #import <objc/runtime.h>
+
+JJSYNTH_DUMMY_CLASS(NSNotificationCenter_ClearNotification)
 
 @implementation NSNotificationCenter (ClearNotification)
 

--- a/JJException/Source/ARC/NSSet+SetHook.m
+++ b/JJException/Source/ARC/NSSet+SetHook.m
@@ -9,6 +9,9 @@
 #import "NSSet+SetHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSSet_SetHook)
 
 @implementation NSSet (SetHook)
 

--- a/JJException/Source/ARC/NSString+StringHook.m
+++ b/JJException/Source/ARC/NSString+StringHook.m
@@ -9,6 +9,9 @@
 #import "NSString+StringHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSString_StringHook)
 
 @implementation NSString (StringHook)
 

--- a/JJException/Source/MRC/NSArray+ArrayHook.m
+++ b/JJException/Source/MRC/NSArray+ArrayHook.m
@@ -9,6 +9,9 @@
 #import "NSArray+ArrayHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSArray_ArrayHook)
 
 @implementation NSArray (ArrayHook)
 

--- a/JJException/Source/MRC/NSDictionary+DictionaryHook.m
+++ b/JJException/Source/MRC/NSDictionary+DictionaryHook.m
@@ -9,6 +9,9 @@
 #import "NSDictionary+DictionaryHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSDictionary_DictionaryHook)
 
 @implementation NSDictionary (DictionaryHook)
 

--- a/JJException/Source/MRC/NSMutableArray+MutableArrayHook.m
+++ b/JJException/Source/MRC/NSMutableArray+MutableArrayHook.m
@@ -9,6 +9,9 @@
 #import "NSMutableArray+MutableArrayHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSMutableArray_MutableArrayHook)
 
 @implementation NSMutableArray (MutableArrayHook)
 

--- a/JJException/Source/MRC/NSMutableDictionary+MutableDictionaryHook.m
+++ b/JJException/Source/MRC/NSMutableDictionary+MutableDictionaryHook.m
@@ -9,6 +9,9 @@
 #import "NSMutableDictionary+MutableDictionaryHook.h"
 #import "NSObject+SwizzleHook.h"
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSMutableDictionary_MutableDictionaryHook)
 
 @implementation NSMutableDictionary (MutableDictionaryHook)
 

--- a/JJException/Source/MRC/NSObject+UnrecognizedSelectorHook.m
+++ b/JJException/Source/MRC/NSObject+UnrecognizedSelectorHook.m
@@ -10,6 +10,9 @@
 #import "NSObject+SwizzleHook.h"
 #import <objc/runtime.h>
 #import "JJExceptionProxy.h"
+#import "JJExceptionMacros.h"
+
+JJSYNTH_DUMMY_CLASS(NSObject_UnrecognizedSelectorHook)
 
 @implementation NSObject (UnrecognizedSelectorHook)
 

--- a/JJException/Source/Main/JJExceptionMacros.h
+++ b/JJException/Source/Main/JJExceptionMacros.h
@@ -1,0 +1,26 @@
+//
+//  JJExceptionMacros.h
+//  JJException
+//
+//  Created by Kealdish on 2019/2/26.
+//  Copyright © 2019 Jezz. All rights reserved.
+//
+
+#ifndef JJExceptionMacros_h
+#define JJExceptionMacros_h
+
+/**
+ Add this macro before each category implementation, so we don't have to use
+ -all_load or -force_load to load object files from static libraries that only
+ contain categories and no classes.
+ *******************************************************************************
+ Example:
+ JJSYNTH_DUMMY_CLASS(NSObject_DeallocBlock)
+ */
+#ifndef JJSYNTH_DUMMY_CLASS
+#define JJSYNTH_DUMMY_CLASS(_name_) \
+@interface JJSYNTH_DUMMY_CLASS_ ## _name_ : NSObject @end \
+@implementation JJSYNTH_DUMMY_CLASS_ ## _name_ @end
+#endif
+
+#endif /* JJExceptionMacros_h */


### PR DESCRIPTION
Add `JJSYNTH_DUMMY_CLASS` macro before each category implementation, so we don't have to use
 `-all_load` or `-force_load` to load object files from **static libraries** that only
 contain categories and no classes.