### PR TITLE
improved the implementation of module NSNotificationCenter

### DIFF
--- a/JJException/PushViewController.m
+++ b/JJException/PushViewController.m
@@ -38,6 +38,8 @@
 
 @property(nonatomic,readwrite,copy)NSString* demoString1;
 
+@property(nonatomic,readwrite,copy)NSString* notificationTest;
+
 @end
 
 @implementation PushViewController
@@ -47,7 +49,8 @@
     
     _kvoDemo = [KVOObjectDemo new];
     _kvoObserver = [KVOObserver new];
-    
+    _notificationTest = @"notificationTest";
+
     [self testTimer];
     
     [self testKVO];
@@ -68,7 +71,7 @@
 #pragma mark - Test Notifiaction
 
 - (void)testNotification{
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(testNotificationObserver) name:@"test" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(testNotificationObserver) name:@"test" object:self.notificationTest];
     
     [[NSNotificationCenter defaultCenter] postNotificationName:@"test" object:nil];
 }

--- a/JJException/Source/ARC/NSNotificationCenter+ClearNotification.h
+++ b/JJException/Source/ARC/NSNotificationCenter+ClearNotification.h
@@ -8,6 +8,51 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ Copy the NSNotification Info
+ */
+@interface JJNotificationObject : NSObject
+
+@property (nonatomic,readwrite,copy) NSString* name;
+
+@property(nonatomic,readwrite,weak)id observer;
+
+@property(nonatomic,readwrite,assign)id object;
+
+/**
+ get key from observer
+
+ @param observer NSNotification observer
+ @return the key of observer info in static NSMutableDictionary
+ */
++ (NSString *)jj_observerInfoKey:(id)observer;
+
+/**
+ set observer info to static NSMutableDictionary
+
+ @param observer NSNotification observer
+ @param name NSNotificationName
+ @param anObject NSNotification object
+ */
++ (void)jj_setNotificationObserverInfo:(id)observer name:(NSNotificationName)name object:(id)anObject;
+
+/**
+ get observer infos array form static NSMutableDictionary
+
+ @param observer NSNotification observer
+ @return array
+ */
++ (NSMutableArray <JJNotificationObject *>* )jj_notificationObserverInfos:(id)observer;
+
+/**
+ remove observer infos from static NSMutableDictionary
+
+ @param observer NSNotification observer
+ */
++ (void)jj_removeNotificationObserverInfo:(id)observer;
+
+@end
+
 @interface NSNotificationCenter (ClearNotification)
 
 + (void)jj_swizzleNSNotificationCenter;

--- a/JJException/Source/ARC/NSNotificationCenter+ClearNotification.m
+++ b/JJException/Source/ARC/NSNotificationCenter+ClearNotification.m
@@ -11,10 +11,90 @@
 #import "NSObject+DeallocBlock.h"
 #import "JJExceptionMacros.h"
 #import <objc/runtime.h>
+#import <pthread.h>
+
+/**
+ Copy the NSNotification Info
+ */
+@interface JJNotificationObject : NSObject
+
+@property (nonatomic,readwrite,copy) NSString* name;
+
+@property(nonatomic,readwrite,weak)id observer;
+
+@property(nonatomic,readwrite,assign)id object;
+
+@end
+
+
+@implementation JJNotificationObject
+
+- (NSString *)debugDescription{
+    return [NSString stringWithFormat:@"<%@: %p> name: %@ observer: %@ object: %@", NSStringFromClass([self class]), self, _name, _observer, _object];
+}
+
+- (NSString *)description{
+    return [self debugDescription];
+}
+
+@end
+
 
 JJSYNTH_DUMMY_CLASS(NSNotificationCenter_ClearNotification)
 
 @implementation NSNotificationCenter (ClearNotification)
+
+static pthread_mutex_t jj_notification_lock;
+static NSMutableDictionary *jj_observerInfo;
+
+NSString * jj_observerInfoKey(id observer){
+    NSString *className = NSStringFromClass([observer class]);
+    NSString *key = [NSString stringWithFormat:@"%@_%p", className, observer];
+    return key;
+}
+
+void jj_setNotificationObserverInfo(id observer, NSNotificationName name, id anObject){
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        pthread_mutex_init(&jj_notification_lock, NULL);
+        jj_observerInfo = [[NSMutableDictionary alloc] init];
+    });
+    JJNotificationObject *observerInfo = [[JJNotificationObject alloc] init];
+    observerInfo.observer = observer;
+    observerInfo.name = name;
+    observerInfo.object = anObject;
+    NSString *key = jj_observerInfoKey(observer);
+    NSMutableArray *infos = jj_notificationObserverInfos(observer);
+    pthread_mutex_lock(&jj_notification_lock);
+    if (!infos) {
+        infos = [[NSMutableArray alloc] init];
+    }
+    [infos addObject:observerInfo];
+    [jj_observerInfo setObject:infos forKey:key];
+    pthread_mutex_unlock(&jj_notification_lock);
+}
+
+NSMutableArray <JJNotificationObject *>* jj_notificationObserverInfos(id observer){
+    if (!jj_observerInfo || (jj_observerInfo.count == 0)) {
+        return nil;
+    }
+    NSMutableArray <JJNotificationObject *>*objcets = nil;
+    NSString *key = jj_observerInfoKey(observer);
+    pthread_mutex_lock(&jj_notification_lock);
+    objcets = [jj_observerInfo objectForKey:key];
+    pthread_mutex_unlock(&jj_notification_lock);
+    return objcets;
+}
+
+void jj_removeNotificationObserverInfo(id observer){
+    if (!jj_observerInfo || (jj_observerInfo.count == 0)) {
+        return ;
+    }
+    NSString *key = jj_observerInfoKey(observer);
+    pthread_mutex_lock(&jj_notification_lock);
+    [jj_observerInfo removeObjectForKey:key];
+    pthread_mutex_unlock(&jj_notification_lock);
+}
 
 + (void)jj_swizzleNSNotificationCenter{
     [self jj_swizzleInstanceMethod:@selector(addObserver:selector:name:object:) withSwizzledBlock:^id(JJSwizzleObject *swizzleInfo) {
@@ -25,15 +105,27 @@ JJSYNTH_DUMMY_CLASS(NSNotificationCenter_ClearNotification)
 }
 
 - (void)processAddObserver:(id)observer selector:(SEL)aSelector name:(NSNotificationName)aName object:(id)anObject swizzleInfo:(JJSwizzleObject*)swizzleInfo{
-    
+
     if (!observer) {
         return;
     }
-    
+
     if ([observer isKindOfClass:NSObject.class]) {
+        jj_setNotificationObserverInfo(observer, aName, anObject);
         __unsafe_unretained typeof(observer) unsafeObject = observer;
         [observer jj_deallocBlock:^{
-            [[NSNotificationCenter defaultCenter] removeObserver:unsafeObject];
+            NSMutableArray <JJNotificationObject *>*infos = jj_notificationObserverInfos(unsafeObject);
+            jj_removeNotificationObserverInfo(unsafeObject);
+            if ([infos isKindOfClass:[NSArray class]] && infos.count > 0) {
+                for (JJNotificationObject *jjObject in infos) {
+                    /**
+                     this is a safe way to remove observer
+                     https://stackoverflow.com/questions/21418726/ios-remove-observer-from-notification-can-i-call-this-once-for-all-observers-a
+                     https://useyourloaf.com/blog/unregistering-nsnotificationcenter-observers-in-ios-9/
+                     */
+                    [[NSNotificationCenter defaultCenter] removeObserver:unsafeObject name:jjObject.name object:jjObject.object];
+                }
+            }
         }];
     }
     

--- a/JJExceptionTests/JJExceptionTests.m
+++ b/JJExceptionTests/JJExceptionTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "JJException.h"
+#import "NSNotificationCenter+ClearNotification.h"
 
 @interface TestZombie : NSObject
 
@@ -202,6 +203,45 @@
             __unused id object = [array objectAtIndex:1];
         }
     }];
+}
+
+- (void)testJJNotificationObserverInfoKey{
+    NSString *str = @"Hello";
+    NSString *key = [JJNotificationObject jj_observerInfoKey:str];
+    BOOL isEqualTo = [key isEqualToString:[NSString stringWithFormat:@"NSString_%p", str]];
+    NSAssert(isEqualTo, @"JJNotificationObject jj_observerInfoKey Failed");
+}
+
+- (void)testJJNotificationSetObserverInfo{
+    TestZombie *test = [[TestZombie alloc] init];
+    [JJNotificationObject jj_setNotificationObserverInfo:test name:UIApplicationDidEnterBackgroundNotification object:@"Test"];
+    NSArray *array = [JJNotificationObject jj_notificationObserverInfos:test];
+    NSAssert([array count] == 1, @"infos error");
+}
+
+- (void)testJJNotificationGetInfos{
+    TestZombie *test = [[TestZombie alloc] init];
+    NSArray *array = [JJNotificationObject jj_notificationObserverInfos:test];
+    NSAssert([array count] == 0, @"infos error");
+    NSString *object = @"Test";
+    [JJNotificationObject jj_setNotificationObserverInfo:test name:UIApplicationDidEnterBackgroundNotification object:object];
+    array = [JJNotificationObject jj_notificationObserverInfos:test];
+    NSAssert([array count] == 1, @"infos error");
+    JJNotificationObject *obj = [array firstObject];
+    NSAssert(obj.name == UIApplicationDidEnterBackgroundNotification, @"JJNotificationObject name error");
+    NSAssert(obj.object == object, @"JJNotificationObject object error");
+}
+
+- (void)testJJNotificationRemoveInfos{
+    TestZombie *test = [[TestZombie alloc] init];
+    //nil remove
+    [JJNotificationObject jj_removeNotificationObserverInfo:test];
+    [JJNotificationObject jj_setNotificationObserverInfo:test name:UIApplicationDidEnterBackgroundNotification object:@"Test"];
+    NSArray *array = [JJNotificationObject jj_notificationObserverInfos:test];
+    NSAssert([array count] == 1, @"infos error");
+    [JJNotificationObject jj_removeNotificationObserverInfo:test];
+    array = [JJNotificationObject jj_notificationObserverInfos:test];
+    NSAssert([array count] == 0, @"infos error");
 }
 
 @end


### PR DESCRIPTION
this is a safe way to remove observer
https://stackoverflow.com/questions/21418726/ios-remove-observer-from-notification-can-i-call-this-once-for-all-observers-a
https://useyourloaf.com/blog/unregistering-nsnotificationcenter-observers-in-ios-9/